### PR TITLE
Feat(HAL): Linear Arena Allocator

### DIFF
--- a/LumenEngine/Source/Core/Private/HAL/Memory/LinearAllocator.cpp
+++ b/LumenEngine/Source/Core/Private/HAL/Memory/LinearAllocator.cpp
@@ -1,0 +1,64 @@
+/**
+ * @file LinearAllocator.cpp
+ * @brief Implementation of the linear allocator.
+ */
+
+#include "HAL/Memory/LinearAllocator.hpp"
+
+#include <bit>
+#include <cassert>
+
+namespace
+{
+
+/**
+ * @brief Aligns a value up to the next multiple of alignment.
+ * @param InValue The value to align.
+ * @param InAlignment The alignment (must be a power of 2).
+ * @return The aligned value.
+ */
+inline LumenEngine::USize AlignUp ( LumenEngine::USize InValue, LumenEngine::USize InAlignment ) noexcept
+{
+    assert( std::has_single_bit( InAlignment ) and "Alignment must be a power of 2" );
+    return ( InValue + ( InAlignment - 1U ) ) & ~( InAlignment - 1U );
+}
+
+} // namespace
+
+LumenEngine::HAL::FLinearAllocator::FLinearAllocator ( void *InBytes, USize InSize ) noexcept
+    : Buffer( static_cast<LumenEngine::Byte *>( InBytes ) ), TotalSize( InSize ), Offset( 0U )
+{
+    /** Ctor */
+}
+
+void *LumenEngine::HAL::FLinearAllocator::Allocate ( USize InSize, USize InAlignment ) noexcept
+{
+    if ( Buffer == nullptr )
+    {
+        return nullptr;
+    }
+
+    const LumenEngine::USize AlignedOffset = AlignUp( Offset, InAlignment );
+
+    /** SECURITY: Check for integer overflow during alignment or if AlignedOffset exceeds TotalSize */
+    if ( AlignedOffset < Offset or AlignedOffset > TotalSize )
+    {
+        return nullptr;
+    }
+
+    /** SECURITY: Check for integer overflow during size addition and ensure we stay within bounds */
+    if ( InSize > TotalSize - AlignedOffset )
+    {
+        return nullptr;
+    }
+
+    void *Pointer = Buffer + AlignedOffset;
+    Offset        = AlignedOffset + InSize;
+
+    return Pointer;
+}
+
+void LumenEngine::HAL::FLinearAllocator::Reset () noexcept
+{
+    Offset = 0U;
+}

--- a/LumenEngine/Source/Core/Private/HAL/Memory/LinearAllocator.cpp
+++ b/LumenEngine/Source/Core/Private/HAL/Memory/LinearAllocator.cpp
@@ -4,12 +4,16 @@
  */
 
 #include "HAL/Memory/LinearAllocator.hpp"
+#include "Logging/Logger.hpp"
 
+#include <algorithm>
 #include <bit>
 #include <cassert>
 
 namespace
 {
+
+const LumenEngine::FLogCategory LogLinearAllocator( "LinearAllocator" );
 
 /**
  * @brief Aligns a value up to the next multiple of alignment.
@@ -26,7 +30,7 @@ inline LumenEngine::USize AlignUp ( LumenEngine::USize InValue, LumenEngine::USi
 } // namespace
 
 LumenEngine::HAL::FLinearAllocator::FLinearAllocator ( void *InBytes, USize InSize ) noexcept
-    : Buffer( static_cast<LumenEngine::Byte *>( InBytes ) ), TotalSize( InSize ), Offset( 0U )
+    : Buffer( static_cast<LumenEngine::Byte *>( InBytes ) ), TotalSize( InSize ), Offset( 0U ), HighWatermark( 0U )
 {
     /** Ctor */
 }
@@ -49,11 +53,22 @@ void *LumenEngine::HAL::FLinearAllocator::Allocate ( USize InSize, USize InAlign
     /** SECURITY: Check for integer overflow during size addition and ensure we stay within bounds */
     if ( InSize > TotalSize - AlignedOffset )
     {
+        if ( InSize > TotalSize )
+        {
+            LUMEN_LOG_WARNING( LogLinearAllocator, "LinearAllocator allocation request ({}) exceeds allocator capacity ({})", InSize, TotalSize );
+        }
+        else
+        {
+            LUMEN_LOG_WARNING( LogLinearAllocator, "LinearAllocator out of scratch memory: requested {}, available {}, high watermark {} of {}", InSize,
+                               TotalSize - AlignedOffset, HighWatermark, TotalSize );
+        }
+
         return nullptr;
     }
 
     void *Pointer = Buffer + AlignedOffset;
     Offset        = AlignedOffset + InSize;
+    HighWatermark = std::max( Offset, HighWatermark );
 
     return Pointer;
 }

--- a/LumenEngine/Source/Core/Public/HAL/Memory/Inline/LinearAllocator.inl
+++ b/LumenEngine/Source/Core/Public/HAL/Memory/Inline/LinearAllocator.inl
@@ -1,0 +1,49 @@
+/**
+ * @file LinearAllocator.inl
+ * @brief Inline implementation of the linear allocator.
+ */
+
+#pragma once
+
+#include <new>
+#include <utility>
+
+template <typename T, typename... TArgs> T *LumenEngine::HAL::FLinearAllocator::New ( TArgs &&...InArgs ) noexcept
+{
+    void *Memory = Allocate( sizeof( T ), alignof( T ) );
+    if ( Memory == nullptr )
+    {
+        return nullptr;
+    }
+
+    return new ( Memory ) T( std::forward<TArgs>( InArgs )... );
+}
+
+inline LumenEngine::USize LumenEngine::HAL::FLinearAllocator::GetUsedMemory () const noexcept
+{
+    return Offset;
+}
+
+inline LumenEngine::USize LumenEngine::HAL::FLinearAllocator::GetTotalMemory () const noexcept
+{
+    return TotalSize;
+}
+
+inline void *LumenEngine::HAL::FLinearAllocator::GetBaseAddress () const noexcept
+{
+    return Buffer;
+}
+
+inline void LumenEngine::HAL::FLinearAllocator::ResetTo ( USize InOffset ) noexcept
+{
+    Offset = InOffset;
+}
+
+inline LumenEngine::HAL::FScopeLinear::FScopeLinear ( FLinearAllocator &InAllocator ) noexcept : Allocator( InAllocator ), PreviousOffset( InAllocator.GetUsedMemory() )
+{
+}
+
+inline LumenEngine::HAL::FScopeLinear::~FScopeLinear () noexcept
+{
+    Allocator.ResetTo( PreviousOffset );
+}

--- a/LumenEngine/Source/Core/Public/HAL/Memory/Inline/LinearAllocator.inl
+++ b/LumenEngine/Source/Core/Public/HAL/Memory/Inline/LinearAllocator.inl
@@ -24,6 +24,11 @@ inline LumenEngine::USize LumenEngine::HAL::FLinearAllocator::GetUsedMemory () c
     return Offset;
 }
 
+inline LumenEngine::USize LumenEngine::HAL::FLinearAllocator::GetHighWatermark () const noexcept
+{
+    return HighWatermark;
+}
+
 inline LumenEngine::USize LumenEngine::HAL::FLinearAllocator::GetTotalMemory () const noexcept
 {
     return TotalSize;

--- a/LumenEngine/Source/Core/Public/HAL/Memory/LinearAllocator.hpp
+++ b/LumenEngine/Source/Core/Public/HAL/Memory/LinearAllocator.hpp
@@ -61,6 +61,7 @@ namespace HAL
          * @tparam ObjectType Type of the object.
          * @tparam TArgs Argument types for the constructor.
          * @param InArgs Arguments for the constructor.
+         * @note If ObjectType owns non-trivial resources, callers must invoke its destructor manually.
          * @return Pointer to the constructed object, or nullptr if allocation failed.
          */
         template <typename ObjectType, typename... TArgs> [[nodiscard]] ObjectType *New ( TArgs &&...InArgs ) noexcept;
@@ -69,6 +70,9 @@ namespace HAL
 
         /** @return Current memory usage in bytes. */
         [[nodiscard]] USize GetUsedMemory () const noexcept;
+
+        /** @return Highest memory usage reached since allocator construction. */
+        [[nodiscard]] USize GetHighWatermark () const noexcept;
 
         /** @return Total capacity in bytes. */
         [[nodiscard]] USize GetTotalMemory () const noexcept;
@@ -89,6 +93,7 @@ namespace HAL
         Byte *Buffer;
         USize TotalSize;
         USize Offset;
+        USize HighWatermark;
 
         friend class FScopeLinear;
 

--- a/LumenEngine/Source/Core/Public/HAL/Memory/LinearAllocator.hpp
+++ b/LumenEngine/Source/Core/Public/HAL/Memory/LinearAllocator.hpp
@@ -1,0 +1,127 @@
+/**
+ * @file LinearAllocator.hpp
+ * @brief Simple and fast linear (arena) allocator for transient data.
+ */
+
+#pragma once
+
+#include "CoreTypes.hpp"
+#include "NonCopyable.hpp"
+#include "NonMovable.hpp"
+
+namespace LumenEngine
+{
+
+namespace HAL
+{
+    /**
+     * @class FLinearAllocator
+     * @brief A non-thread-safe allocator that allocates memory linearly from a pre-allocated block.
+     *
+     * This allocator is intended for high-performance transient data where allocations are
+     * many and small, and can be cleared all at once with zero cost.
+     *
+     * @warning This allocator does NOT track object lifetimes. If you use New<T>(),
+     * you are responsible for manually calling the destructor if T is not a POD.
+     * Resetting or destroying the allocator will not call destructors for allocated objects.
+     */
+    class FLinearAllocator final : public FNonCopyable, public FNonMovable
+    {
+    public:
+
+        /**
+         * @brief Constructs a linear allocator wrapping an existing memory block.
+         * @param InBytes Pointer to the memory block.
+         * @param InSize Size of the memory block in bytes.
+         */
+        explicit FLinearAllocator ( void *InBytes, USize InSize ) noexcept;
+
+        /**
+         * @brief Default destructor. Does NOT free the wrapped buffer.
+         */
+        ~FLinearAllocator () noexcept = default;
+
+    public:
+
+        /**
+         * @brief Allocates a block of memory.
+         * @param InSize Size in bytes.
+         * @param InAlignment Alignment in bytes (must be a power of 2).
+         * @return Pointer to the allocated memory, or nullptr if out of memory.
+         */
+        [[nodiscard]] void *Allocate ( USize InSize, USize InAlignment = 16U ) noexcept;
+
+        /**
+         * @brief Resets the allocator offset to zero.
+         */
+        void Reset () noexcept;
+
+        /**
+         * @brief Helper to construct an object in the allocated memory.
+         * @tparam ObjectType Type of the object.
+         * @tparam TArgs Argument types for the constructor.
+         * @param InArgs Arguments for the constructor.
+         * @return Pointer to the constructed object, or nullptr if allocation failed.
+         */
+        template <typename ObjectType, typename... TArgs> [[nodiscard]] ObjectType *New ( TArgs &&...InArgs ) noexcept;
+
+    public:
+
+        /** @return Current memory usage in bytes. */
+        [[nodiscard]] USize GetUsedMemory () const noexcept;
+
+        /** @return Total capacity in bytes. */
+        [[nodiscard]] USize GetTotalMemory () const noexcept;
+
+        /** @return Base address of the wrapped buffer. */
+        [[nodiscard]] void *GetBaseAddress () const noexcept;
+
+    private:
+
+        /**
+         * @brief Resets the allocator offset to a specific value.
+         * @param InOffset The new offset.
+         */
+        void ResetTo ( USize InOffset ) noexcept;
+
+    private:
+
+        Byte *Buffer;
+        USize TotalSize;
+        USize Offset;
+
+        friend class FScopeLinear;
+
+    }; // class FLinearAllocator
+
+    /**
+     * @class FScopeLinear
+     * @brief RAII guard to automatically reset a linear allocator to its previous state.
+     */
+    class FScopeLinear final : public FNonCopyable, public FNonMovable
+    {
+    public:
+
+        /**
+         * @brief Captures the current state of the allocator.
+         * @param InAllocator The allocator to guard.
+         */
+        explicit FScopeLinear ( FLinearAllocator &InAllocator ) noexcept;
+
+        /**
+         * @brief Restores the allocator to the captured state.
+         */
+        ~FScopeLinear () noexcept;
+
+    private:
+
+        FLinearAllocator &Allocator;
+        USize PreviousOffset;
+
+    }; // class FScopeLinear
+
+} // namespace HAL
+
+} // namespace LumenEngine
+
+#include "Inline/LinearAllocator.inl"

--- a/LumenEngine/Source/Core/Tests/Functional/HAL/Memory/LinearAllocatorTest.cpp
+++ b/LumenEngine/Source/Core/Tests/Functional/HAL/Memory/LinearAllocatorTest.cpp
@@ -28,13 +28,16 @@ TEST( HALMemoryLinearAllocator, AllocationAndReset )
     void *Ptr2 = Allocator.Allocate( 128ULL );
     EXPECT_NE( Ptr2, nullptr );
     EXPECT_EQ( Allocator.GetUsedMemory(), 256ULL );
+    EXPECT_EQ( Allocator.GetHighWatermark(), 256ULL );
     EXPECT_EQ( static_cast<Byte *>( Ptr2 ) - static_cast<Byte *>( Ptr1 ), static_cast<ISize>( 128 ) );
 
     Allocator.Reset();
     EXPECT_EQ( Allocator.GetUsedMemory(), 0ULL );
+    EXPECT_EQ( Allocator.GetHighWatermark(), 256ULL );
 
     void *Ptr3 = Allocator.Allocate( 64ULL );
     EXPECT_EQ( Ptr3, Ptr1 );
+    EXPECT_EQ( Allocator.GetHighWatermark(), 256ULL );
 }
 
 TEST( HALMemoryLinearAllocator, Alignment )
@@ -133,6 +136,7 @@ TEST( HALMemoryLinearAllocator, NestedScopeGuard )
         EXPECT_EQ( Allocator.GetUsedMemory(), 200ULL );
     }
     EXPECT_EQ( Allocator.GetUsedMemory(), 100ULL );
+    EXPECT_EQ( Allocator.GetHighWatermark(), 300ULL );
 }
 
 TEST( HALMemoryLinearAllocator, OverflowProtection )

--- a/LumenEngine/Source/Core/Tests/Functional/HAL/Memory/LinearAllocatorTest.cpp
+++ b/LumenEngine/Source/Core/Tests/Functional/HAL/Memory/LinearAllocatorTest.cpp
@@ -1,0 +1,268 @@
+/**
+ * @file LinearAllocatorTest.cpp
+ * @brief Unit tests for FLinearAllocator in LumenEngine
+ */
+
+#include "HAL/Memory/LinearAllocator.hpp"
+#include "Container/UniquePtr.hpp"
+#include "CoreTypes.hpp"
+#include "HAL/PlatformTime.hpp"
+
+#include <gtest/gtest.h>
+#include <iostream>
+#include <thread>
+#include <vector>
+
+TEST( HALMemoryLinearAllocator, AllocationAndReset )
+{
+    using namespace LumenEngine;
+    using namespace LumenEngine::HAL;
+
+    alignas( 16 ) Byte Buffer[1024];
+    FLinearAllocator Allocator( Buffer, 1024ULL );
+
+    void *Ptr1 = Allocator.Allocate( 128ULL );
+    EXPECT_NE( Ptr1, nullptr );
+    EXPECT_EQ( Allocator.GetUsedMemory(), 128ULL );
+
+    void *Ptr2 = Allocator.Allocate( 128ULL );
+    EXPECT_NE( Ptr2, nullptr );
+    EXPECT_EQ( Allocator.GetUsedMemory(), 256ULL );
+    EXPECT_EQ( static_cast<Byte *>( Ptr2 ) - static_cast<Byte *>( Ptr1 ), static_cast<ISize>( 128 ) );
+
+    Allocator.Reset();
+    EXPECT_EQ( Allocator.GetUsedMemory(), 0ULL );
+
+    void *Ptr3 = Allocator.Allocate( 64ULL );
+    EXPECT_EQ( Ptr3, Ptr1 );
+}
+
+TEST( HALMemoryLinearAllocator, Alignment )
+{
+    using namespace LumenEngine;
+    using namespace LumenEngine::HAL;
+
+    alignas( 16 ) Byte Buffer[1024];
+    FLinearAllocator Allocator( Buffer, 1024ULL );
+
+    // Initial allocation
+    ( void )Allocator.Allocate( 1ULL );
+    EXPECT_EQ( Allocator.GetUsedMemory(), 1ULL );
+
+    // Next allocation with 16-byte alignment
+    void *Ptr = Allocator.Allocate( 16ULL, 16ULL );
+    EXPECT_EQ( reinterpret_cast<UPtr>( Ptr ) % 16ULL, reinterpret_cast<UPtr>( Buffer ) % 16ULL );
+    EXPECT_EQ( Allocator.GetUsedMemory(), 32ULL );
+}
+
+TEST( HALMemoryLinearAllocator, OutOfMemory )
+{
+    using namespace LumenEngine;
+    using namespace LumenEngine::HAL;
+
+    Byte Buffer[64];
+    FLinearAllocator Allocator( Buffer, 64ULL );
+
+    void *Ptr1 = Allocator.Allocate( 64ULL );
+    EXPECT_NE( Ptr1, nullptr );
+
+    void *Ptr2 = Allocator.Allocate( 1ULL );
+    EXPECT_EQ( Ptr2, nullptr );
+}
+
+TEST( HALMemoryLinearAllocator, NewObject )
+{
+    using namespace LumenEngine;
+    using namespace LumenEngine::HAL;
+
+    struct FTestObject
+    {
+        Int32 Value;
+        FTestObject ( Int32 InValue ) : Value( InValue )
+        {
+        }
+    };
+
+    alignas( alignof( FTestObject ) ) Byte Buffer[1024];
+    FLinearAllocator Allocator( Buffer, 1024ULL );
+
+    FTestObject *Obj = Allocator.New<FTestObject>( 42 );
+    ASSERT_NE( Obj, nullptr );
+    EXPECT_EQ( Obj->Value, 42 );
+}
+
+TEST( HALMemoryLinearAllocator, ScopeGuard )
+{
+    using namespace LumenEngine;
+    using namespace LumenEngine::HAL;
+
+    Byte Buffer[1024];
+    FLinearAllocator Allocator( Buffer, 1024ULL );
+
+    // Use alignment of 1 to avoid surprises in math
+    ( void )Allocator.Allocate( 100ULL, 1ULL );
+    USize OffsetBefore = Allocator.GetUsedMemory();
+
+    {
+        FScopeLinear Scope( Allocator );
+        ( void )Allocator.Allocate( 200ULL, 1ULL );
+        EXPECT_EQ( Allocator.GetUsedMemory(), OffsetBefore + 200ULL );
+    }
+
+    EXPECT_EQ( Allocator.GetUsedMemory(), OffsetBefore );
+}
+
+TEST( HALMemoryLinearAllocator, NestedScopeGuard )
+{
+    using namespace LumenEngine;
+    using namespace LumenEngine::HAL;
+
+    Byte Buffer[1024];
+    FLinearAllocator Allocator( Buffer, 1024ULL );
+
+    ( void )Allocator.Allocate( 100ULL, 1ULL );
+    {
+        FScopeLinear Scope1( Allocator );
+        ( void )Allocator.Allocate( 100ULL, 1ULL );
+        EXPECT_EQ( Allocator.GetUsedMemory(), 200ULL );
+        {
+            FScopeLinear Scope2( Allocator );
+            ( void )Allocator.Allocate( 100ULL, 1ULL );
+            EXPECT_EQ( Allocator.GetUsedMemory(), 300ULL );
+        }
+        EXPECT_EQ( Allocator.GetUsedMemory(), 200ULL );
+    }
+    EXPECT_EQ( Allocator.GetUsedMemory(), 100ULL );
+}
+
+TEST( HALMemoryLinearAllocator, OverflowProtection )
+{
+    using namespace LumenEngine;
+    using namespace LumenEngine::HAL;
+
+    Byte Buffer[1024];
+    FLinearAllocator Allocator( Buffer, 1024ULL );
+
+    // Try to allocate more than possible with a huge size
+    void *Ptr1 = Allocator.Allocate( ~0ULL );
+    EXPECT_EQ( Ptr1, nullptr );
+
+    // Note: Overflow in AlignUp is hard to catch without extra checks in AlignUp itself.
+    // But we can check if it returns nullptr for impossible alignments.
+    // Current implementation doesn't handle huge alignments well if they overflow USize.
+}
+
+TEST( HALMemoryLinearAllocator, NullBuffer )
+{
+    using namespace LumenEngine;
+    using namespace LumenEngine::HAL;
+
+    FLinearAllocator Allocator( nullptr, 1024ULL );
+    void *Ptr = Allocator.Allocate( 1ULL );
+    EXPECT_EQ( Ptr, nullptr );
+}
+
+TEST( HALMemoryLinearAllocator, EdgeCases )
+{
+    using namespace LumenEngine;
+    using namespace LumenEngine::HAL;
+
+    Byte Buffer[1024];
+    FLinearAllocator Allocator( Buffer, 1024ULL );
+
+    // 1. Zero size allocation
+    USize UsedBefore = Allocator.GetUsedMemory();
+    void *Ptr0       = Allocator.Allocate( 0ULL );
+    EXPECT_NE( Ptr0, nullptr );
+    EXPECT_EQ( Allocator.GetUsedMemory(), UsedBefore );
+
+    // 2. Exact fit
+    Allocator.Reset();
+    void *PtrFull = Allocator.Allocate( 1024ULL, 1ULL );
+    EXPECT_NE( PtrFull, nullptr );
+    EXPECT_EQ( Allocator.GetUsedMemory(), 1024ULL );
+    EXPECT_EQ( Allocator.Allocate( 1ULL ), nullptr );
+
+    // 3. Large alignment
+    Byte LargeBuffer[4096];
+    FLinearAllocator LargeAllocator( LargeBuffer, 4096ULL );
+    ( void )LargeAllocator.Allocate( 1ULL, 1ULL );
+    void *PtrPage = LargeAllocator.Allocate( 1ULL, 1024ULL );
+    EXPECT_NE( PtrPage, nullptr );
+    EXPECT_EQ( LargeAllocator.GetUsedMemory(), 1025ULL );
+
+    // 4. Alignment 1
+    void *PtrAlign1 = LargeAllocator.Allocate( 1ULL, 1ULL );
+    EXPECT_NE( PtrAlign1, nullptr );
+    EXPECT_EQ( LargeAllocator.GetUsedMemory(), 1026ULL );
+}
+
+TEST( HALMemoryLinearAllocator, Performance )
+{
+    using namespace LumenEngine;
+    using namespace LumenEngine::HAL;
+
+    const USize NumAllocations = 1000000;
+    const USize AllocSize      = 16ULL;
+    const USize TotalRequired  = NumAllocations * ( AllocSize + 16ULL );
+
+    TUniquePtr<Byte[]> Buffer = MakeUnique<Byte[]>( TotalRequired );
+    FLinearAllocator Allocator( Buffer.Get(), TotalRequired );
+
+    Float64 Start = FPlatformTime::Seconds();
+    for ( USize i = 0; i < NumAllocations; ++i )
+    {
+        void *Ptr = Allocator.Allocate( AllocSize );
+        // Touch memory to prevent optimization
+        if ( Ptr )
+        {
+            *static_cast<volatile Byte *>( Ptr ) = static_cast<Byte>( i & 0xFF );
+        }
+    }
+    Float64 End = FPlatformTime::Seconds();
+
+    std::cout << "[          ] LinearAllocator: " << NumAllocations << " allocations took " << ( End - Start ) * 1000.0 << " ms" << std::endl;
+}
+
+TEST( HALMemoryLinearAllocator, ParallelAllocators )
+{
+    using namespace LumenEngine;
+    using namespace LumenEngine::HAL;
+
+    const Int32 NumThreads           = 8;
+    const USize AllocationsPerThread = 10000;
+    std::vector<std::jthread> Threads;
+    TAtomic<Int32> SuccessCount = 0;
+
+    for ( Int32 i = 0; i < NumThreads; ++i )
+    {
+        Threads.emplace_back(
+            [&SuccessCount] ()
+            {
+                // Use heap buffer for thread safety and to avoid stack issues
+                auto LocalBuffer = MakeUnique<Byte[]>( 1024 * 256 );
+                FLinearAllocator Allocator( LocalBuffer.Get(), 1024 * 256 );
+
+                Bool bThreadSuccess = true;
+                for ( USize j = 0; j < AllocationsPerThread; ++j )
+                {
+                    void *Ptr = Allocator.Allocate( 8ULL );
+                    if ( !Ptr )
+                    {
+                        bThreadSuccess = false;
+                        break;
+                    }
+                    *static_cast<volatile UInt64 *>( Ptr ) = j;
+                }
+
+                if ( bThreadSuccess )
+                {
+                    SuccessCount.fetch_add( 1, std::memory_order_relaxed );
+                }
+            } );
+    }
+
+    Threads.clear(); // jthread joins automatically
+
+    EXPECT_EQ( SuccessCount.load(), NumThreads );
+}

--- a/LumenEngine/Source/Parallel/Private/Thread/WorkerPool.cpp
+++ b/LumenEngine/Source/Parallel/Private/Thread/WorkerPool.cpp
@@ -5,13 +5,21 @@
 
 #include "Thread/WorkerPool.hpp"
 
+#include "Container/UniquePtr.hpp"
+
 #include <bit>
+#include <cassert>
 
 namespace
 {
 
 thread_local LumenEngine::Bool bLumenIsWorkerThread      = false;
 thread_local LumenEngine::UInt32 LumenCurrentWorkerIndex = 0U;
+
+/** INFO: Each worker thread gets a 1MB scratch buffer for transient allocations */
+constexpr LumenEngine::USize LumenWorkerScratchSize = 1024ULL * 1024ULL;
+thread_local LumenEngine::TUniquePtr<LumenEngine::Byte[]> LumenWorkerScratchBuffer;
+thread_local LumenEngine::TOptional<LumenEngine::HAL::FLinearAllocator> LumenWorkerAllocator;
 
 } // namespace
 
@@ -109,6 +117,12 @@ LumenEngine::TOptional<LumenEngine::UInt32> LumenEngine::Parallel::FWorkerPool::
     return LumenCurrentWorkerIndex;
 }
 
+LumenEngine::HAL::FLinearAllocator &LumenEngine::Parallel::FWorkerPool::GetWorkerAllocator () noexcept
+{
+    assert( LumenWorkerAllocator.has_value() and "GetWorkerAllocator() called from a non-worker thread or before initialization." );
+    return *LumenWorkerAllocator;
+}
+
 LumenEngine::TVector<LumenEngine::UInt64> LumenEngine::Parallel::FWorkerPool::GetWorkerExecutionCounts () const noexcept
 {
     TVector<UInt64> Result;
@@ -139,6 +153,9 @@ void LumenEngine::Parallel::FWorkerPool::WorkerLoop ( UInt32 InWorkerIndex ) noe
     bLumenIsWorkerThread    = true;
     LumenCurrentWorkerIndex = InWorkerIndex;
 
+    LumenWorkerScratchBuffer = MakeUnique<Byte[]>( LumenWorkerScratchSize );
+    LumenWorkerAllocator.emplace( LumenWorkerScratchBuffer.Get(), LumenWorkerScratchSize );
+
     while ( bIsActive.load( std::memory_order_acquire ) )
     {
         TaskSemaphore.acquire();
@@ -150,13 +167,20 @@ void LumenEngine::Parallel::FWorkerPool::WorkerLoop ( UInt32 InWorkerIndex ) noe
 
         if ( TOptional<FTask> Task = Queue.Pop() )
         {
-            ( *Task )();
+            {
+                HAL::FScopeLinear Scope( *LumenWorkerAllocator );
+                ( *Task )();
+            }
+
             WorkerExecutionCounts[InWorkerIndex].fetch_add( 1ULL, std::memory_order_relaxed );
 
             ActiveTaskCount.fetch_sub( 1U, std::memory_order_release );
             ActiveTaskCount.notify_all();
         }
     }
+
+    LumenWorkerAllocator.reset();
+    LumenWorkerScratchBuffer.Reset();
 
     bLumenIsWorkerThread = false;
 }

--- a/LumenEngine/Source/Parallel/Public/Thread/WorkerPool.hpp
+++ b/LumenEngine/Source/Parallel/Public/Thread/WorkerPool.hpp
@@ -10,6 +10,7 @@
 #include "NonCopyable.hpp"
 #include "NonMovable.hpp"
 
+#include "HAL/Memory/LinearAllocator.hpp"
 #include "Thread/SPMCQueue.hpp"
 
 #include <functional>
@@ -37,7 +38,7 @@ namespace Parallel
          * @param InWorkerCount The number of hardware threads to allocate.
          * @param InQueueCapacity The maximum number of pending tasks (will be rounded up to the nearest power of 2).
          */
-        explicit FWorkerPool ( UInt32 InWorkerCount, std::size_t InQueueCapacity = 1024ULL ) noexcept;
+        explicit FWorkerPool ( UInt32 InWorkerCount, USize InQueueCapacity = 1024ULL ) noexcept;
 
         /**
          * @brief Cleans up workers gracefully. Calls Shutdown() automatically.
@@ -68,6 +69,13 @@ namespace Parallel
          * @return Worker index bound to the calling thread, or empty if called from outside the pool.
          */
         static TOptional<UInt32> GetCurrentWorkerIndex () noexcept;
+
+        /**
+         * @brief Returns the linear allocator for the current worker thread.
+         * @return Reference to the worker's linear allocator.
+         * @note Only valid when called from a worker thread. Behavior is undefined otherwise.
+         */
+        static HAL::FLinearAllocator &GetWorkerAllocator () noexcept;
 
         /**
          * @brief Snapshot of executed task count per worker.

--- a/LumenEngine/Source/Parallel/Tests/Functional/Thread/LinearAllocatorIntegrationTest.cpp
+++ b/LumenEngine/Source/Parallel/Tests/Functional/Thread/LinearAllocatorIntegrationTest.cpp
@@ -1,0 +1,49 @@
+/**
+ * @file LinearAllocatorIntegrationTest.cpp
+ * @brief Integration tests for FLinearAllocator with FWorkerPool
+ */
+
+#include "CoreTypes.hpp"
+#include "HAL/Memory/LinearAllocator.hpp"
+#include "Thread/WorkerPool.hpp"
+
+#include <gtest/gtest.h>
+
+TEST( ParallelWorkerPool, LinearAllocatorIntegration )
+{
+    using namespace LumenEngine;
+    using namespace LumenEngine::Parallel;
+
+    FWorkerPool Pool( 4U, 64ULL );
+    TAtomic<Bool> bSuccess = true;
+
+    for ( UInt32 Index = 0; Index < 100; ++Index )
+    {
+        Pool.Submit(
+            [&bSuccess] ()
+            {
+                HAL::FLinearAllocator &Allocator = FWorkerPool::GetWorkerAllocator();
+
+                // At the start of the task, it should be empty because of FScopeLinear in WorkerLoop
+                if ( Allocator.GetUsedMemory() != 0ULL )
+                {
+                    bSuccess = false;
+                }
+
+                void *Ptr = Allocator.Allocate( 1024ULL );
+                if ( Ptr == nullptr )
+                {
+                    bSuccess = false;
+                    return;
+                }
+
+                if ( Allocator.GetUsedMemory() != 1024ULL )
+                {
+                    bSuccess = false;
+                }
+            } );
+    }
+
+    Pool.WaitAll();
+    EXPECT_TRUE( bSuccess.load() );
+}


### PR DESCRIPTION
# Feat(HAL): Linear / Arena Allocator

**Module**: `Source/Core/Public/HAL/Memory/` (New)
**Title:** Implement `FLinearAllocator` for Per-Frame Transient Memory

**Description:**
The engine currently relies on the global heap (`new`/`delete`) for transient frame data and task payloads, which introduces significant synchronization overhead and fragmentation. To achieve AAA-level performance in the `FWorld::Tick` loop, we need a thread-local Linear Allocator.

**Requirements:**
- [ ] Implement `FLinearAllocator` capable of wrapping a pre-allocated block of memory.
- [ ] Ensure the allocator is non-thread-safe (used per-worker-thread).
- [ ] Integrate with `Parallel::FWorkerPool` tasks so they can allocate temporary scratch memory with zero-cost resets.
- [ ] Provide a `ScopeLinear` guard to automate pointer resetting after task completion.

