### PR TITLE
Refactor(VulkanRHI): Replace Static Global Uniform Buffer Allocation

### DIFF
--- a/LumenEngine/Source/VulkanRHI/Private/Vulkan/VulkanMemory.cpp
+++ b/LumenEngine/Source/VulkanRHI/Private/Vulkan/VulkanMemory.cpp
@@ -7,6 +7,8 @@
 
 #include "Vulkan/VulkanCore.hpp"
 #include "Vulkan/VulkanDescriptorWriter.hpp"
+
+#include <cassert>
 #include <cstring>
 #include <vulkan/vulkan_core.h>
 
@@ -157,6 +159,9 @@ CreateVmaAllocatorInfo ( VkInstance InInstance, VkPhysicalDevice InPhysicalDevic
 
 void LumenEngine::VulkanRHI::FVulkanMemory::Initialize ( VkInstance InInstance, VkPhysicalDevice InPhysicalDevice, VkDevice InDevice, const FDescriptorConfig &InConfig )
 {
+    assert( NumFramesInFlight == 0U and "FVulkanMemory is already initialized. Call Shutdown first." );
+    assert( InConfig.MaxFramesInFlight <= 8U and "Frames in flight configuration exceeds maximum allowed threshold." );
+
     NumFramesInFlight = InConfig.MaxFramesInFlight;
     InitializeVMA( InInstance, InPhysicalDevice, InDevice );
     InitializeDescriptors( InDevice );

--- a/LumenEngine/Source/VulkanRHI/Private/Vulkan/VulkanMemory.cpp
+++ b/LumenEngine/Source/VulkanRHI/Private/Vulkan/VulkanMemory.cpp
@@ -91,18 +91,24 @@ namespace
     return Layout;
 }
 
-void CreateDescriptorPool ( VkDevice InDevice, VkDescriptorPool &OutPool )
+void CreateDescriptorPool ( VkDevice InDevice, LumenEngine::UInt32 InMaxFramesInFlight, VkDescriptorPool &OutPool )
 {
+    if ( InMaxFramesInFlight == 0U )
+    {
+        OutPool = VK_NULL_HANDLE;
+        return;
+    }
+
     const VkDescriptorPoolSize PoolSizes[] = {
-        { .type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, .descriptorCount = LumenEngine::VulkanRHI::MaxFramesInFlight },
-        { .type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, .descriptorCount = LumenEngine::VulkanRHI::MaxFramesInFlight * 4U },
+        { .type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, .descriptorCount = InMaxFramesInFlight },
+        { .type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, .descriptorCount = InMaxFramesInFlight * 4U },
     };
 
     VkDescriptorPoolCreateInfo PoolInfo{
         .sType         = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
         .pNext         = nullptr,
         .flags         = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT,
-        .maxSets       = LumenEngine::VulkanRHI::MaxFramesInFlight * 4U,
+        .maxSets       = InMaxFramesInFlight * 4U,
         .poolSizeCount = 2U,
         .pPoolSizes    = PoolSizes,
     };
@@ -149,8 +155,9 @@ CreateVmaAllocatorInfo ( VkInstance InInstance, VkPhysicalDevice InPhysicalDevic
 
 } // namespace
 
-void LumenEngine::VulkanRHI::FVulkanMemory::Initialize ( VkInstance InInstance, VkPhysicalDevice InPhysicalDevice, VkDevice InDevice )
+void LumenEngine::VulkanRHI::FVulkanMemory::Initialize ( VkInstance InInstance, VkPhysicalDevice InPhysicalDevice, VkDevice InDevice, const FDescriptorConfig &InConfig )
 {
+    NumFramesInFlight = InConfig.MaxFramesInFlight;
     InitializeVMA( InInstance, InPhysicalDevice, InDevice );
     InitializeDescriptors( InDevice );
 }
@@ -177,12 +184,20 @@ void LumenEngine::VulkanRHI::FVulkanMemory::InitializeDescriptors ( VkDevice InD
     SceneSetLayout  = CreateSceneSetLayout( InDevice );
     CullSetLayout   = CreateCullSetLayout( InDevice );
 
-    CreateDescriptorPool( InDevice, DescriptorPool );
+    CreateDescriptorPool( InDevice, NumFramesInFlight, DescriptorPool );
+
+    if ( NumFramesInFlight == 0U )
+    {
+        return;
+    }
+
+    GlobalUniformBuffers.resize( NumFramesInFlight );
+    GlobalDescriptorSets.resize( NumFramesInFlight );
 
     VkBufferCreateInfo BufferInfo     = CreateBufferInfo( sizeof( FGPUGlobalUniforms ) );
     VmaAllocationCreateInfo AllocInfo = CreateVmaAllocationInfo();
 
-    for ( UInt32 Index = 0U; Index < MaxFramesInFlight; ++Index )
+    for ( UInt32 Index = 0U; Index < NumFramesInFlight; ++Index )
     {
         LUMEN_VK_CHECK( vmaCreateBuffer( Allocator, &BufferInfo, &AllocInfo, &GlobalUniformBuffers[Index].Buffer, &GlobalUniformBuffers[Index].Allocation,
                                          &GlobalUniformBuffers[Index].AllocationInfo ) );
@@ -206,27 +221,35 @@ void LumenEngine::VulkanRHI::FVulkanMemory::DestroyDescriptors ( VkDevice InDevi
     if ( DescriptorPool != VK_NULL_HANDLE )
     {
         vkDestroyDescriptorPool( InDevice, DescriptorPool, nullptr );
+        DescriptorPool = VK_NULL_HANDLE;
     }
     if ( GlobalSetLayout != VK_NULL_HANDLE )
     {
         vkDestroyDescriptorSetLayout( InDevice, GlobalSetLayout, nullptr );
+        GlobalSetLayout = VK_NULL_HANDLE;
     }
     if ( SceneSetLayout != VK_NULL_HANDLE )
     {
         vkDestroyDescriptorSetLayout( InDevice, SceneSetLayout, nullptr );
+        SceneSetLayout = VK_NULL_HANDLE;
     }
     if ( CullSetLayout != VK_NULL_HANDLE )
     {
         vkDestroyDescriptorSetLayout( InDevice, CullSetLayout, nullptr );
+        CullSetLayout = VK_NULL_HANDLE;
     }
 
-    for ( UInt32 Index = 0U; Index < MaxFramesInFlight; ++Index )
+    for ( UInt32 Index = 0U; Index < NumFramesInFlight; ++Index )
     {
         if ( GlobalUniformBuffers[Index].Buffer != VK_NULL_HANDLE )
         {
             vmaDestroyBuffer( Allocator, GlobalUniformBuffers[Index].Buffer, GlobalUniformBuffers[Index].Allocation );
         }
     }
+
+    GlobalUniformBuffers.clear();
+    GlobalDescriptorSets.clear();
+    NumFramesInFlight = 0U;
 }
 
 void LumenEngine::VulkanRHI::FVulkanMemory::DestroyVMA () noexcept
@@ -234,11 +257,16 @@ void LumenEngine::VulkanRHI::FVulkanMemory::DestroyVMA () noexcept
     if ( Allocator != VK_NULL_HANDLE )
     {
         vmaDestroyAllocator( Allocator );
+        Allocator = VK_NULL_HANDLE;
     }
 }
 
 void LumenEngine::VulkanRHI::FVulkanMemory::UpdateGlobalUniformData ( UInt32 InFrameIndex, const FGPUGlobalUniforms &InUniforms ) noexcept
 {
+    if ( InFrameIndex >= NumFramesInFlight or GlobalUniformBuffers[InFrameIndex].Buffer == VK_NULL_HANDLE )
+    {
+        return;
+    }
     std::memcpy( GlobalUniformBuffers[InFrameIndex].AllocationInfo.pMappedData, &InUniforms, sizeof( FGPUGlobalUniforms ) );
     vmaFlushAllocation( Allocator, GlobalUniformBuffers[InFrameIndex].Allocation, 0, sizeof( FGPUGlobalUniforms ) );
 }
@@ -260,6 +288,11 @@ VkDescriptorPool LumenEngine::VulkanRHI::FVulkanMemory::GetDescriptorPool () con
     return DescriptorPool;
 }
 
+LumenEngine::UInt32 LumenEngine::VulkanRHI::FVulkanMemory::GetNumFramesInFlight () const noexcept
+{
+    return NumFramesInFlight;
+}
+
 VkDescriptorSetLayout LumenEngine::VulkanRHI::FVulkanMemory::GetGlobalSetLayout () const noexcept
 {
     return GlobalSetLayout;
@@ -277,5 +310,9 @@ VkDescriptorSetLayout LumenEngine::VulkanRHI::FVulkanMemory::GetCullSetLayout ()
 
 VkDescriptorSet LumenEngine::VulkanRHI::FVulkanMemory::GetGlobalDescriptorSet ( UInt32 InFrameIndex ) const noexcept
 {
+    if ( InFrameIndex >= NumFramesInFlight )
+    {
+        return VK_NULL_HANDLE;
+    }
     return GlobalDescriptorSets[InFrameIndex];
 }

--- a/LumenEngine/Source/VulkanRHI/Private/Vulkan/VulkanRHI.cpp
+++ b/LumenEngine/Source/VulkanRHI/Private/Vulkan/VulkanRHI.cpp
@@ -30,7 +30,8 @@ void LumenEngine::VulkanRHI::FVulkanRHI::Initialize ( const LumenEngine::TShared
 
     InitializeVulkanInstance( InWindow );
     InitializeVulkanDevice();
-    Memory.Initialize( Instance.GetHandle(), PhysicalDevice.GetHandle(), LogicalDevice.GetHandle() );
+    const FDescriptorConfig Config{ .MaxFramesInFlight = MaxFramesInFlight };
+    Memory.Initialize( Instance.GetHandle(), PhysicalDevice.GetHandle(), LogicalDevice.GetHandle(), Config );
     InitializeSwapChain( InWindow );
     FrameContext.Initialize( LogicalDevice.GetHandle(), LogicalDevice.GetGraphicsQueueFamily() );
 
@@ -169,7 +170,17 @@ LumenEngine::Bool LumenEngine::VulkanRHI::FVulkanRHI::BeginFrame ( const RHI::FG
     const LumenEngine::UInt64 AbsoluteFrame = FrameContext.GetAbsoluteFrameIndex();
     DeferredDestructionQueue.Tick( AbsoluteFrame );
 
+    const LumenEngine::UInt32 NumFrames = Memory.GetNumFramesInFlight();
+    if ( NumFrames == 0U )
+    {
+        return false;
+    }
+
     const LumenEngine::UInt32 CurrentFrame = FrameContext.GetCurrentFrameIndex();
+    if ( CurrentFrame >= NumFrames )
+    {
+        return false;
+    }
 
     Memory.UpdateGlobalUniformData( CurrentFrame, InUniforms );
 
@@ -234,6 +245,11 @@ void LumenEngine::VulkanRHI::FVulkanRHI::BindPipelineInternal ( VkCommandBuffer 
 
     const UInt32 CurrentFrame           = FrameContext.GetCurrentFrameIndex();
     VkDescriptorSet GlobalDescriptorSet = Memory.GetGlobalDescriptorSet( CurrentFrame );
+
+    if ( GlobalDescriptorSet == VK_NULL_HANDLE )
+    {
+        return;
+    }
 
     vkCmdBindDescriptorSets( InCmd, VK_PIPELINE_BIND_POINT_GRAPHICS, Pipeline->GetLayout(), 0, 1, &GlobalDescriptorSet, 0, nullptr );
 }
@@ -372,6 +388,11 @@ void LumenEngine::VulkanRHI::FVulkanRHI::DestroyPipeline ( RHI::FPipelineHandle 
 
 void LumenEngine::VulkanRHI::FVulkanRHI::InitializeGpuDrivenResources ( const RHI::FShaderByteCode &InComputeCode )
 {
+    if ( Memory.GetDescriptorPool() == VK_NULL_HANDLE )
+    {
+        return;
+    }
+
     SceneBuffer.Initialize( Memory.GetAllocator(), LogicalDevice.GetHandle(), Memory.GetDescriptorPool(), Memory.GetSceneSetLayout() );
     IndirectBuffer.Initialize( Memory.GetAllocator(), LogicalDevice.GetHandle(), Memory.GetDescriptorPool(), Memory.GetCullSetLayout() );
 

--- a/LumenEngine/Source/VulkanRHI/Public/Vulkan/VulkanMemory.hpp
+++ b/LumenEngine/Source/VulkanRHI/Public/Vulkan/VulkanMemory.hpp
@@ -10,6 +10,7 @@
 #include "CoreTypes.hpp"
 #include "RHI/RHITypes.hpp"
 
+#include "Container/Vector.hpp"
 #include "Vulkan/GPUDriven/GPUGlobalUniforms.hpp"
 #include "Vulkan/VulkanBuffer.hpp"
 #include "Vulkan/VulkanCore.hpp"
@@ -21,6 +22,15 @@ namespace LumenEngine
 
 namespace VulkanRHI
 {
+
+    /**
+     * @struct FDescriptorConfig
+     * @brief Runtime configuration for descriptors and uniform buffers.
+     */
+    struct FDescriptorConfig final
+    {
+        UInt32 MaxFramesInFlight = 0U;
+    };
 
     /**
      * @class FVulkanMemory
@@ -47,8 +57,9 @@ namespace VulkanRHI
          * @param InInstance       The Vulkan instance.
          * @param InPhysicalDevice The physical device.
          * @param InDevice         The logical device.
+         * @param InConfig         The descriptor configuration.
          */
-        void Initialize ( VkInstance InInstance, VkPhysicalDevice InPhysicalDevice, VkDevice InDevice );
+        void Initialize ( VkInstance InInstance, VkPhysicalDevice InPhysicalDevice, VkDevice InDevice, const FDescriptorConfig &InConfig );
 
         /**
          * @brief Shuts down the Vulkan memory manager.
@@ -72,6 +83,7 @@ namespace VulkanRHI
 
         [[nodiscard]] VmaAllocator GetAllocator () const noexcept;
         [[nodiscard]] VkDescriptorPool GetDescriptorPool () const noexcept;
+        [[nodiscard]] UInt32 GetNumFramesInFlight () const noexcept;
 
         /* set=0 */
         [[nodiscard]] VkDescriptorSetLayout GetGlobalSetLayout () const noexcept;
@@ -95,9 +107,9 @@ namespace VulkanRHI
     private:
 
         /** set=0 — Global UBO */
-        VkDescriptorSetLayout GlobalSetLayout                   = VK_NULL_HANDLE;
-        VkDescriptorSet GlobalDescriptorSets[MaxFramesInFlight] = {};
-        FVulkanBuffer GlobalUniformBuffers[MaxFramesInFlight]   = {};
+        VkDescriptorSetLayout GlobalSetLayout = VK_NULL_HANDLE;
+        TVector<VkDescriptorSet> GlobalDescriptorSets;
+        TVector<FVulkanBuffer> GlobalUniformBuffers;
 
         /** set=1 — Scene SSBO layout (sets owned by FGPUSceneBuffer) */
         VkDescriptorSetLayout SceneSetLayout = VK_NULL_HANDLE;
@@ -109,6 +121,8 @@ namespace VulkanRHI
         VkDescriptorPool DescriptorPool = VK_NULL_HANDLE;
 
         VmaAllocator Allocator = VK_NULL_HANDLE;
+
+        UInt32 NumFramesInFlight = 0U;
     };
 
 } // namespace VulkanRHI

--- a/LumenEngine/Source/VulkanRHI/Tests/Functional/VulkanMemoryTest.cpp
+++ b/LumenEngine/Source/VulkanRHI/Tests/Functional/VulkanMemoryTest.cpp
@@ -1,0 +1,297 @@
+/**
+ * @file VulkanMemoryTest.cpp
+ * @brief Functional unit tests for LumenEngine::VulkanRHI::FVulkanMemory dynamic descriptor and buffer allocation.
+ LumenEngine::VulkanRHI::*/
+
+#include "Vulkan/VulkanMemory.hpp"
+#include "Vulkan/GPUDriven/GPUGlobalUniforms.hpp"
+#include "Vulkan/VulkanBuffer.hpp"
+#include "Vulkan/VulkanCore.hpp"
+
+#include <cstring>
+#include <gtest/gtest.h>
+
+namespace
+{
+
+LumenEngine::UInt32 GBufferCount = 0U;
+LumenEngine::UInt8 GMockMappedMemory[4U][256U];
+
+inline void ResetMockState () noexcept
+{
+    GBufferCount = 0U;
+    std::memset( GMockMappedMemory, 0, sizeof( GMockMappedMemory ) );
+}
+
+} // namespace
+
+extern "C"
+{
+    VkResult vmaCreateAllocator ( const VmaAllocatorCreateInfo *InCreateInfo, VmaAllocator *OutAllocator )
+    {
+        ( void )InCreateInfo;
+        *OutAllocator = reinterpret_cast<VmaAllocator>( 0x1234ULL );
+        return VK_SUCCESS;
+    }
+
+    void vmaDestroyAllocator ( VmaAllocator InAllocator )
+    {
+        ( void )InAllocator;
+    }
+
+    VkResult vmaCreateBuffer ( VmaAllocator InAllocator,
+                               const VkBufferCreateInfo *InBufferInfo,
+                               const VmaAllocationCreateInfo *InAllocationInfo,
+                               VkBuffer *OutBuffer,
+                               VmaAllocation *OutAllocation,
+                               VmaAllocationInfo *OutAllocationInfo )
+    {
+        ( void )InAllocator;
+        ( void )InAllocationInfo;
+
+        const uint32_t Index = GBufferCount % 4U;
+        ++GBufferCount;
+
+        *OutBuffer     = reinterpret_cast<VkBuffer>( static_cast<uintptr_t>( 0x5678U + Index ) );
+        *OutAllocation = reinterpret_cast<VmaAllocation>( static_cast<uintptr_t>( 0x9abcU + Index ) );
+
+        if ( OutAllocationInfo != nullptr )
+        {
+            OutAllocationInfo->offset      = 0U;
+            OutAllocationInfo->size        = InBufferInfo->size;
+            OutAllocationInfo->pMappedData = GMockMappedMemory[Index];
+        }
+
+        return VK_SUCCESS;
+    }
+
+    void vmaDestroyBuffer ( VmaAllocator InAllocator, VkBuffer InBuffer, VmaAllocation InAllocation )
+    {
+        ( void )InAllocator;
+        ( void )InBuffer;
+        ( void )InAllocation;
+    }
+
+    VkResult vmaFlushAllocation ( VmaAllocator InAllocator, VmaAllocation InAllocation, VkDeviceSize InOffset, VkDeviceSize InSize )
+    {
+        ( void )InAllocator;
+        ( void )InAllocation;
+        ( void )InOffset;
+        ( void )InSize;
+        return VK_SUCCESS;
+    }
+
+    VkResult vkCreateDescriptorSetLayout ( VkDevice InDevice,
+                                           const VkDescriptorSetLayoutCreateInfo *InCreateInfo,
+                                           const VkAllocationCallbacks *InAllocator,
+                                           VkDescriptorSetLayout *OutSetLayout )
+    {
+        ( void )InDevice;
+        ( void )InCreateInfo;
+        ( void )InAllocator;
+
+        static uintptr_t SLayoutCounter = 0x1111ULL;
+        *OutSetLayout                   = reinterpret_cast<VkDescriptorSetLayout>( SLayoutCounter++ );
+        return VK_SUCCESS;
+    }
+
+    void vkDestroyDescriptorSetLayout ( VkDevice InDevice, VkDescriptorSetLayout InDescriptorSetLayout, const VkAllocationCallbacks *InAllocator )
+    {
+        ( void )InDevice;
+        ( void )InDescriptorSetLayout;
+        ( void )InAllocator;
+    }
+
+    VkResult vkCreateDescriptorPool ( VkDevice InDevice,
+                                      const VkDescriptorPoolCreateInfo *InCreateInfo,
+                                      const VkAllocationCallbacks *InAllocator,
+                                      VkDescriptorPool *OutDescriptorPool )
+    {
+        ( void )InDevice;
+        ( void )InCreateInfo;
+        ( void )InAllocator;
+
+        *OutDescriptorPool = reinterpret_cast<VkDescriptorPool>( 0x2222ULL );
+        return VK_SUCCESS;
+    }
+
+    void vkDestroyDescriptorPool ( VkDevice InDevice, VkDescriptorPool InDescriptorPool, const VkAllocationCallbacks *InAllocator )
+    {
+        ( void )InDevice;
+        ( void )InDescriptorPool;
+        ( void )InAllocator;
+    }
+
+    VkResult vkAllocateDescriptorSets ( VkDevice InDevice, const VkDescriptorSetAllocateInfo *InAllocateInfo, VkDescriptorSet *OutDescriptorSets )
+    {
+        ( void )InDevice;
+
+        static uintptr_t SSetCounter = 0x3333ULL;
+        for ( uint32_t Index = 0U; Index < InAllocateInfo->descriptorSetCount; ++Index )
+        {
+            OutDescriptorSets[Index] = reinterpret_cast<VkDescriptorSet>( SSetCounter++ );
+        }
+        return VK_SUCCESS;
+    }
+
+    void vkUpdateDescriptorSets ( VkDevice InDevice,
+                                  uint32_t InDescriptorWriteCount,
+                                  const VkWriteDescriptorSet *InDescriptorWrites,
+                                  uint32_t InDescriptorCopyCount,
+                                  const VkCopyDescriptorSet *InDescriptorCopies )
+    {
+        ( void )InDevice;
+        ( void )InDescriptorWriteCount;
+        ( void )InDescriptorWrites;
+        ( void )InDescriptorCopyCount;
+        ( void )InDescriptorCopies;
+    }
+}
+
+/**
+ * @class FVulkanMemoryTest
+ * @brief GTest fixture that resets mock allocator state before every test.
+ */
+class FVulkanMemoryTest : public ::testing::Test
+{
+protected:
+
+    void SetUp () override
+    {
+        ResetMockState();
+    }
+};
+
+/**
+ * @brief Test 1: Config with valid MaxFramesInFlight initializes vectors to correct size.
+ */
+TEST_F( FVulkanMemoryTest, InitializeValidFramesInFlight )
+{
+    LumenEngine::VulkanRHI::FVulkanMemory Memory;
+    LumenEngine::VulkanRHI::FDescriptorConfig Config;
+    Config.MaxFramesInFlight = 2U;
+
+    VkInstance DummyInstance         = reinterpret_cast<VkInstance>( 0xDEADBEEF1111ULL );
+    VkPhysicalDevice DummyPhysDevice = reinterpret_cast<VkPhysicalDevice>( 0xDEADBEEF2222ULL );
+    VkDevice DummyDevice             = reinterpret_cast<VkDevice>( 0xDEADBEEF3333ULL );
+
+    Memory.Initialize( DummyInstance, DummyPhysDevice, DummyDevice, Config );
+
+    EXPECT_EQ( Memory.GetNumFramesInFlight(), 2U );
+    EXPECT_NE( Memory.GetAllocator(), VK_NULL_HANDLE );
+    EXPECT_NE( Memory.GetDescriptorPool(), VK_NULL_HANDLE );
+
+    EXPECT_NE( Memory.GetGlobalSetLayout(), VK_NULL_HANDLE );
+    EXPECT_NE( Memory.GetSceneSetLayout(), VK_NULL_HANDLE );
+    EXPECT_NE( Memory.GetCullSetLayout(), VK_NULL_HANDLE );
+
+    EXPECT_NE( Memory.GetGlobalDescriptorSet( 0U ), VK_NULL_HANDLE );
+    EXPECT_NE( Memory.GetGlobalDescriptorSet( 1U ), VK_NULL_HANDLE );
+
+    Memory.Shutdown( DummyDevice );
+}
+
+/**
+ * @brief Test 2: GetNumFramesInFlight returns the correct count.
+ */
+TEST_F( FVulkanMemoryTest, GetNumFramesInFlightReturnsCorrectCount )
+{
+    LumenEngine::VulkanRHI::FVulkanMemory Memory;
+    LumenEngine::VulkanRHI::FDescriptorConfig Config;
+    Config.MaxFramesInFlight = 3U;
+
+    VkDevice DummyDevice = reinterpret_cast<VkDevice>( 0xDEADBEEF3333ULL );
+
+    Memory.Initialize( VK_NULL_HANDLE, VK_NULL_HANDLE, DummyDevice, Config );
+
+    EXPECT_EQ( Memory.GetNumFramesInFlight(), 3U );
+
+    VkDescriptorSet Set0 = Memory.GetGlobalDescriptorSet( 0U );
+    VkDescriptorSet Set1 = Memory.GetGlobalDescriptorSet( 1U );
+    VkDescriptorSet Set2 = Memory.GetGlobalDescriptorSet( 2U );
+
+    EXPECT_NE( Set0, VK_NULL_HANDLE );
+    EXPECT_NE( Set1, VK_NULL_HANDLE );
+    EXPECT_NE( Set2, VK_NULL_HANDLE );
+
+    EXPECT_NE( Set0, Set1 );
+    EXPECT_NE( Set1, Set2 );
+
+    Memory.Shutdown( DummyDevice );
+}
+
+/**
+ * @brief Test 3: FDescriptorConfig with MaxFramesInFlight = 0 initializes gracefully.
+ */
+TEST_F( FVulkanMemoryTest, InitializeZeroFramesInFlight )
+{
+    LumenEngine::VulkanRHI::FVulkanMemory Memory;
+    LumenEngine::VulkanRHI::FDescriptorConfig Config;
+    Config.MaxFramesInFlight = 0U;
+
+    VkDevice DummyDevice = reinterpret_cast<VkDevice>( 0xDEADBEEF3333ULL );
+
+    Memory.Initialize( VK_NULL_HANDLE, VK_NULL_HANDLE, DummyDevice, Config );
+
+    EXPECT_EQ( Memory.GetNumFramesInFlight(), 0U );
+    EXPECT_NE( Memory.GetAllocator(), VK_NULL_HANDLE );
+    EXPECT_EQ( Memory.GetDescriptorPool(), VK_NULL_HANDLE );
+
+    EXPECT_EQ( Memory.GetGlobalDescriptorSet( 0U ), VK_NULL_HANDLE );
+
+    LumenEngine::VulkanRHI::FGPUGlobalUniforms Uniforms;
+    Uniforms.TimeSeconds = 42.F;
+    Memory.UpdateGlobalUniformData( 0U, Uniforms );
+
+    Memory.Shutdown( DummyDevice );
+}
+
+/**
+ * @brief Test 4: Bounds checking works for GetGlobalDescriptorSet and UpdateGlobalUniformData.
+ */
+TEST_F( FVulkanMemoryTest, BoundsCheckingForGetAndUpdate )
+{
+    LumenEngine::VulkanRHI::FVulkanMemory Memory;
+    LumenEngine::VulkanRHI::FDescriptorConfig Config;
+    Config.MaxFramesInFlight = 2U;
+
+    VkDevice DummyDevice = reinterpret_cast<VkDevice>( 0xDEADBEEF3333ULL );
+
+    Memory.Initialize( VK_NULL_HANDLE, VK_NULL_HANDLE, DummyDevice, Config );
+
+    LumenEngine::VulkanRHI::FGPUGlobalUniforms UniformsFrame0;
+    UniformsFrame0.TimeSeconds = 10.5F;
+    UniformsFrame0.DeltaTime   = 0.016F;
+
+    LumenEngine::VulkanRHI::FGPUGlobalUniforms UniformsFrame1;
+    UniformsFrame1.TimeSeconds = 11.0F;
+    UniformsFrame1.DeltaTime   = 0.033F;
+
+    Memory.UpdateGlobalUniformData( 0U, UniformsFrame0 );
+    Memory.UpdateGlobalUniformData( 1U, UniformsFrame1 );
+
+    const LumenEngine::VulkanRHI::FGPUGlobalUniforms *CopiedFrame0 = reinterpret_cast<const LumenEngine::VulkanRHI::FGPUGlobalUniforms *>( GMockMappedMemory[0U] );
+    const LumenEngine::VulkanRHI::FGPUGlobalUniforms *CopiedFrame1 = reinterpret_cast<const LumenEngine::VulkanRHI::FGPUGlobalUniforms *>( GMockMappedMemory[1U] );
+
+    EXPECT_FLOAT_EQ( CopiedFrame0->TimeSeconds, 10.5F );
+    EXPECT_FLOAT_EQ( CopiedFrame0->DeltaTime, 0.016F );
+    EXPECT_FLOAT_EQ( CopiedFrame1->TimeSeconds, 11.0F );
+    EXPECT_FLOAT_EQ( CopiedFrame1->DeltaTime, 0.033F );
+
+    EXPECT_EQ( Memory.GetGlobalDescriptorSet( 2U ), VK_NULL_HANDLE );
+    EXPECT_EQ( Memory.GetGlobalDescriptorSet( 999U ), VK_NULL_HANDLE );
+
+    LumenEngine::VulkanRHI::FGPUGlobalUniforms BadUniforms;
+    BadUniforms.TimeSeconds = 999.F;
+
+    const LumenEngine::VulkanRHI::FGPUGlobalUniforms *CopiedFrame2 = reinterpret_cast<const LumenEngine::VulkanRHI::FGPUGlobalUniforms *>( GMockMappedMemory[2U] );
+    const LumenEngine::VulkanRHI::FGPUGlobalUniforms *CopiedFrame3 = reinterpret_cast<const LumenEngine::VulkanRHI::FGPUGlobalUniforms *>( GMockMappedMemory[3U] );
+
+    Memory.UpdateGlobalUniformData( 2U, BadUniforms );
+    Memory.UpdateGlobalUniformData( 999U, BadUniforms );
+
+    EXPECT_FLOAT_EQ( CopiedFrame2->TimeSeconds, 0.0F );
+    EXPECT_FLOAT_EQ( CopiedFrame3->TimeSeconds, 0.0F );
+
+    Memory.Shutdown( DummyDevice );
+}

--- a/LumenEngine/Source/VulkanRHI/Tests/Functional/VulkanMemoryTest.cpp
+++ b/LumenEngine/Source/VulkanRHI/Tests/Functional/VulkanMemoryTest.cpp
@@ -1,7 +1,7 @@
 /**
  * @file VulkanMemoryTest.cpp
  * @brief Functional unit tests for LumenEngine::VulkanRHI::FVulkanMemory dynamic descriptor and buffer allocation.
- LumenEngine::VulkanRHI::*/
+ */
 
 #include "Vulkan/VulkanMemory.hpp"
 #include "Vulkan/GPUDriven/GPUGlobalUniforms.hpp"

--- a/Scripts/LumenBuild/Tasks/Helper.py
+++ b/Scripts/LumenBuild/Tasks/Helper.py
@@ -9,7 +9,7 @@ def PrintHelp(ctx):
 
     print(f"""
 {C.BOLD}{C.CYAN}╔══════════════════════════════════════════════════════╗
-║           Lumen Build System  v0.1.0                ║
+║           Lumen Build System  v0.1.0                 ║
 ╚══════════════════════════════════════════════════════╝{C.RESET}
 
 {C.BOLD}USAGE{C.RESET}
@@ -61,4 +61,7 @@ def PrintHelp(ctx):
 
   {C.GREEN}lumen clean --release{C.RESET}
       Remove Release/ build artefacts only.
+
+  {C.GREEN}lumen tidy --module <Module>{C.RESET}
+      Run clang-tidy on a specific module (e.g. Core, Renderer).
 """)


### PR DESCRIPTION
# Refactor(VulkanRHI): Replace static global uniform buffer allocation

**Description:** The `FVulkanMemory` class currently relies on `MaxFramesInFlight` hardcoded constants for `GlobalUniformBuffers`. To support complex scenes with higher memory requirements or varying frame-in-flight counts, this must be made dynamic.

**Tasks:**
- [x] Refactor `FVulkanMemory` to accept a `FDescriptorConfig` struct during `Initialize()`.
- [x] Dynamically allocate `GlobalUniformBuffers` array based on the config rather than hardcoded constants.
- [x] Update `FVulkanRHI::BeginFrame` to query the dynamic count during memory access.

**Acceptance Criteria:**
- [x] Memory allocation succeeds when varying `MaxFramesInFlight` at runtime.
- [x] No regression in performance when accessing global uniform buffers.
- [x] System handles `VK_NULL_HANDLE` gracefully if allocation size is invalid.
