### PR TITLE
Feat(Scripts): Add lumen init invoke

### DIFF
--- a/LumenEngine/Source/Parallel/Public/Thread/Inline/SPMCQueue.inl
+++ b/LumenEngine/Source/Parallel/Public/Thread/Inline/SPMCQueue.inl
@@ -8,7 +8,7 @@
 #include "Thread/SPMCQueue.hpp"
 
 template <typename Type>
-LumenEngine::Parallel::TSPMCQueue<Type>::TSPMCQueue ( USize InCapacity )
+LumenEngine::Parallel::TSPMCQueue<Type>::TSPMCQueue( USize InCapacity )
     : OwnedBuffer( LumenEngine::MakeUnique<FCell[]>( InCapacity ) ),
       /* */
       CapacityMask( InCapacity - 1ULL ),

--- a/Scripts/LumenBuild/Registry.py
+++ b/Scripts/LumenBuild/Registry.py
@@ -1,17 +1,23 @@
 from invoke import (
     Collection as InvokeCollection,
+)
+from invoke import (
     Program as InvokeProgram,
 )
 
 from LumenBuild.Tasks.Build import (
     BuildDebug as FBuildDebug,
-    BuildRelease as FBuildRelease,
+)
+from LumenBuild.Tasks.Build import (
     BuildHelp as FBuildHelp,
 )
-
+from LumenBuild.Tasks.Build import (
+    BuildRelease as FBuildRelease,
+)
 from LumenBuild.Tasks.Clean import Clean as FClean
 from LumenBuild.Tasks.Format import Format as FFormat
 from LumenBuild.Tasks.Helper import PrintHelp as FHelp
+from LumenBuild.Tasks.Initialize import Initialize as FInitialize
 from LumenBuild.Tasks.Test import Test as FTest
 from LumenBuild.Tasks.Tidy import Tidy as FTidy
 
@@ -27,5 +33,6 @@ ns.add_task(FFormat, name="format")
 ns.add_task(FTidy, name="tidy")
 ns.add_task(FClean, name="clean")
 ns.add_task(FHelp, name="help")
+ns.add_task(FInitialize, name="init")
 
 program = InvokeProgram(namespace=ns, version="0.1.0")

--- a/Scripts/LumenBuild/Tasks/Helper.py
+++ b/Scripts/LumenBuild/Tasks/Helper.py
@@ -1,67 +1,57 @@
 from invoke import task
 
-from LumenBuild.Constants import EAnsiColor as C, SANITIZER_FLAGS
+from LumenBuild.Constants import SANITIZER_FLAGS
+from LumenBuild.Constants import EAnsiColor as C
+
+
+def _GetVersion() -> str:
+    try:
+        with open("VERSION.md", "r") as f:
+            return f.read().strip()
+    except Exception:
+        return "unknown"
 
 
 @task(name="help")
 def PrintHelp(ctx):
+    version = _GetVersion()
     sanitizers = " | ".join(SANITIZER_FLAGS)
 
     print(f"""
-{C.BOLD}{C.CYAN}╔══════════════════════════════════════════════════════╗
-║           Lumen Build System  v0.1.0                 ║
-╚══════════════════════════════════════════════════════╝{C.RESET}
+{C.BOLD}{C.CYAN}Lumen Build System v{version}{C.RESET}
 
 {C.BOLD}USAGE{C.RESET}
   lumen <command>[.<subcommand>] [options]
 
+{C.BOLD}INITIALIZATION COMMANDS{C.RESET}
+
+  {C.GREEN}lumen init <name> [--directory <dir>] [--force]{C.RESET}
+    Create a new Lumen project with the specified name.
+
 {C.BOLD}BUILD COMMANDS{C.RESET}
 
-  {C.GREEN}lumen build.debug{C.RESET}  (alias: {C.GREEN}build.d{C.RESET})
-      Configure + compile in Debug mode.
+  {C.GREEN}lumen build.debug [--sanitizer <s>] [--target <Target>] [--testing]{C.RESET}
+    Build in Debug mode (alias lumen build.d)
+    Where valid sanitizers are:
+    {C.YELLOW}{sanitizers}{C.RESET}
 
-  {C.GREEN}lumen build.debug --sanitizer <s>{C.RESET}
-      Debug build with a sanitizer.
-      Available: {C.YELLOW}{sanitizers}{C.RESET}
+  {C.GREEN}lumen build.release [--lto] [--target <Target>] [--testing]{C.RESET}
+    Build in Release mode (alias lumen build.r)
 
-  {C.GREEN}lumen build.debug --target <Target>{C.RESET}
-      Build a single CMake target (e.g. Core, Renderer).
+{C.BOLD}TESTING COMMANDS{C.RESET}
 
-  {C.GREEN}lumen build.debug --testing{C.RESET}
-      Enable test targets (requires GoogleTest).
-
-  {C.GREEN}lumen build.release{C.RESET}  (alias: {C.GREEN}build.r{C.RESET})
-      Configure + compile in Release mode (-O3).
-
-  {C.GREEN}lumen build.release --lto{C.RESET}
-      Release build with Link-Time Optimisation.
-
-  {C.GREEN}lumen build.help{C.RESET}
-      Detailed build subcommand reference.
+  {C.GREEN}lumen test [--filter <regex>]{C.RESET}
+    Run LumenEngine's CTest-based unit tests.
 
 {C.BOLD}OTHER COMMANDS{C.RESET}
 
-  {C.GREEN}lumen test{C.RESET}
-      Run all CTest tests (parallel, Debug build).
+  {C.GREEN}lumen clean [--debug | --release]{C.RESET}
+    Wipe the entire [Build/<Config>] directory.
+    By default, both Debug and Release artefacts are removed.
 
-  {C.GREEN}lumen test --filter <regex>{C.RESET}
-      Run only tests matching the pattern.
-
-  {C.GREEN}lumen format{C.RESET}
-      Run clang-format in parallel over all C++ sources.
-
-  {C.GREEN}lumen format --check{C.RESET}
-      Verify formatting without modifying files (CI mode).
-
-  {C.GREEN}lumen clean{C.RESET}
-      Wipe the entire Build/ directory.
-
-  {C.GREEN}lumen clean --debug{C.RESET}
-      Remove Debug/ build artefacts only.
-
-  {C.GREEN}lumen clean --release{C.RESET}
-      Remove Release/ build artefacts only.
+  {C.GREEN}lumen format [--check]{C.RESET}
+    Run clang-format in parallel over all C++ sources.
 
   {C.GREEN}lumen tidy --module <Module>{C.RESET}
-      Run clang-tidy on a specific module (e.g. Core, Renderer).
+    Run clang-tidy on a specific module (e.g. Core, Renderer).
 """)

--- a/Scripts/LumenBuild/Tasks/Initialize.py
+++ b/Scripts/LumenBuild/Tasks/Initialize.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import re
+import shutil
+from pathlib import Path
+
+from invoke import task
+
+from LumenBuild.Constants import EAnsiColor as C
+from LumenBuild.Utils import Log, LogError, LogOk, LogWarn
+
+
+def _ToSnakeCase(name: str) -> str:
+    return re.sub(r"(?<!^)(?=[A-Z])", "_", name).upper()
+
+
+def _GenerateCppTemplates(
+    name: str,
+    project_dir: Path,
+) -> dict[Path, str]:
+    macro_name = f"LUMEN_{_ToSnakeCase(name)}_ASSET_PATH"
+
+    return {
+        project_dir / "CMakeLists.txt": f"""
+LumenModule(
+    NAME            {name}
+    TYPE            executable
+    SOURCES         "Private/*.cpp"
+    PUBLIC_INCLUDES "Public"
+    DEFINES         LUMEN_ENGINE
+    DEPS            Launch Renderer Engine Compiler
+)
+
+###########################################################
+
+target_compile_definitions(
+    {name}
+    PRIVATE
+    {macro_name}="${{CMAKE_CURRENT_SOURCE_DIR}}/{name}/Assets"
+)
+""",
+        project_dir / "Public" / "Application.hpp": f"""
+/**
+ * @file Application.hpp
+ * @brief Declaration of the F{name}Application class for the {name} application
+ */
+
+#pragma once
+
+#include "CoreTypes.hpp"
+
+#include "GameApplication.hpp"
+
+#include "Assets/AssetCompiler.hpp"
+#include "World/World.hpp"
+
+namespace LumenEngine
+{{
+
+class F{name}Application final : public IGameApplication
+{{
+public:
+
+    Int32 Initialize ( Int32 Argc, const AnsiChar *Argv[] ) override;
+    void Tick ( const Float64 InDeltaTime ) override;
+    void Shutdown () override;
+
+private:
+
+    TUniquePtr<Engine::FWorld> World;
+    TUniquePtr<Engine::FAssetCompiler> AssetCompiler;
+}};
+
+}} // namespace LumenEngine
+""",
+        project_dir / "Private" / "Application.cpp": f"""
+/**
+ * @file Application.cpp
+ * @brief Implementation of the F{name}Application class
+ */
+
+#include "Application.hpp"
+
+#include "ErrorCodes.hpp"
+#include "MessageHandler.hpp"
+
+#include "Generic/GenericApplication.hpp"
+
+#include "Logging/Logger.hpp"
+
+#ifndef {macro_name}
+    #define {macro_name} ""
+#endif
+
+namespace
+{{
+
+LUMEN_LOG_DEFINE_CATEGORY( Log{name}, "{name}" );
+
+}}
+
+/**
+ * Public
+ */
+
+LumenEngine::Int32 LumenEngine::F{name}Application::Initialize ( const Int32 LUMEN_UNUSED Argc, const AnsiChar LUMEN_UNUSED *Argv[] )
+{{
+    if ( not GPlatformApplication.IsValid() )
+    {{
+        return EErrorCode::Failure;
+    }};
+
+    GPlatformApplication->SetMessageHandler( MakeShared<F{name}ApplicationMessageHandler>() );
+
+    World = MakeUnique<Engine::FWorld>();
+
+    AssetCompiler = MakeUnique<Engine::FAssetCompiler>();
+    AssetCompiler->Initialize( {macro_name} );
+
+    LUMEN_LOG_INFO( Log{name}, "World initialized with Camera, Scene and Mesh actors." );
+    return EErrorCode::Success;
+}}
+
+void LumenEngine::F{name}Application::Shutdown ()
+{{
+    AssetCompiler.Reset();
+    World.Reset();
+}}
+
+void LumenEngine::F{name}Application::Tick ( const Float64 InDeltaTime )
+{{
+    AssetCompiler->Tick();
+    World->Tick( InDeltaTime );
+}}
+
+/**
+ * Private
+ */
+
+LUMEN_REGISTER_GAME_APPLICATION( LumenEngine::F{name}Application );
+""",
+        project_dir / "Public" / "MessageHandler.hpp": f"""
+/**
+ * @file MessageHandler.hpp
+ * @brief Declaration of the F{name}ApplicationMessageHandler class
+ */
+
+#pragma once
+
+#include "Generic/GenericApplicationMessageHandler.hpp"
+
+namespace LumenEngine
+{{
+
+class F{name}ApplicationMessageHandler final : public FGenericApplicationMessageHandler
+{{
+public:
+
+    void OnRequestExit () override;
+}};
+
+}} // namespace LumenEngine
+""",
+        project_dir / "Private" / "MessageHandler.cpp": f"""
+/**
+ * @file MessageHandler.cpp
+ * @brief Message handler implementation for the {name} application
+ */
+
+#include "MessageHandler.hpp"
+#include "LaunchEngineLoop.hpp"
+
+void LumenEngine::F{name}ApplicationMessageHandler::OnRequestExit ()
+{{
+    GEngineLoop.RequestExit( "Event: Application exit requested" );
+}}
+""",
+    }
+
+
+def _GeneratePublicPrivateTemplates(name: str, project_dir: Path) -> None:
+    cpp_templates: dict[Path, str] = _GenerateCppTemplates(name, project_dir)
+
+    for path, content in cpp_templates.items():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+
+def _GenerateAssetTemplates(project_dir: Path) -> None:
+    ASSET_TYPES = ("Materials", "Meshes", "Shaders")
+
+    for sub_dir in ASSET_TYPES:
+        (project_dir / "Assets" / sub_dir).mkdir(parents=True, exist_ok=True)
+
+
+def _GenerateTemplates(name: str, project_dir: Path) -> None:
+    try:
+        _GeneratePublicPrivateTemplates(name, project_dir)
+        _GenerateAssetTemplates(project_dir)
+        LogOk(f"Project '{name}' successfully initialized at {project_dir.resolve()}")
+
+    except OSError as err:
+        LogError(f"Failed to create project structure: {err}")
+
+
+@task(
+    name="initialize",
+    help={
+        "name": "Mandatory name of the project to create",
+        "directory": "Parent directory where the project directory will be created",
+        "force": "Force initialization even if the target directory already exists",
+    },
+)
+def Initialize(ctx, name: str, directory: str = ".", force: bool = False) -> None:
+    Log(
+        f"{C.BOLD}Initializing project '{name}'{C.RESET}  —  LumenEngine",
+        prefix="INIT ",
+        color=C.CYAN,
+    )
+
+    if not re.match(r"^[a-zA-Z][a-zA-Z0-9_]*$", name):
+        LogError(
+            f"Invalid project name '{name}'. It must start with a letter and "
+            "only contain alphanumeric characters or underscores."
+        )
+        return
+
+    project_dir = Path(directory) / name
+
+    if project_dir.exists():
+        LogWarn(f"Target directory already exists: {project_dir.resolve()}")
+
+        if not force:
+            Log("Use the '--force' flag to overwrite the existing directory.")
+            return
+
+        else:
+            Log("Overwriting existing directory due to '--force' flag.")
+            shutil.rmtree(project_dir)
+
+    _GenerateTemplates(name, project_dir)


### PR DESCRIPTION
```console
Lumen Build System v0.1.0

USAGE
  lumen <command>[.<subcommand>] [options]

INITIALIZATION COMMANDS

  lumen init <name> [--directory <dir>] [--force]
    Create a new Lumen project with the specified name.

BUILD COMMANDS

  lumen build.debug [--sanitizer <s>] [--target <Target>] [--testing]
    Build in Debug mode (alias lumen build.d)
    Where valid sanitizers are:
    asan | ubsan | tsan

  lumen build.release [--lto] [--target <Target>] [--testing]
    Build in Release mode (alias lumen build.r)

TESTING COMMANDS

  lumen test [--filter <regex>]
    Run LumenEngine's CTest-based unit tests.

OTHER COMMANDS

  lumen clean [--debug | --release]
    Wipe the entire [Build/<Config>] directory.
    By default, both Debug and Release artefacts are removed.

  lumen format [--check]
    Run clang-format in parallel over all C++ sources.

  lumen tidy --module <Module>
    Run clang-tidy on a specific module (e.g. Core, Renderer).
    ```